### PR TITLE
fix: hydration mismatch, HTTPS media, and console noise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ BACKEND_URL=http://localhost:3000
 # BACKEND_URL=https://backend.vincelivemix.fr
 
 # Public origin of this Next app (RSS links, SSR axios base URL). Must match how you open the site locally.
+# Production: use https:// (e.g. https://www.vincelivemix.fr) so generated links match the live site.
 HOST=http://localhost:3001
 
 # Google Analytics / gtag measurement ID (optional; leave empty to disable)

--- a/src/components/audioplayer/audioplayer-style.tsx
+++ b/src/components/audioplayer/audioplayer-style.tsx
@@ -2,20 +2,20 @@ import styled, { css, keyframes } from 'styled-components';
 import { PreloadState } from './preload-state.enum';
 
 type PlayPauseWrapperProps = {
-  playing: boolean;
+  $playing: boolean;
 };
 
 type PlayPauseButtonProps = {
-  playing: boolean;
-  preloadState: PreloadState;
+  $playing: boolean;
+  $preloadState: PreloadState;
 };
 
 type VolumeProps = {
-  size: number;
+  $size: number;
 };
 
 type BarPlayedProps = {
-  percent: number;
+  $percent: number;
 };
 
 const rotateLoader = keyframes`
@@ -47,7 +47,7 @@ export const PlayPauseWrapper = styled.div<PlayPauseWrapperProps>`
   width: 35px;
   height: 35px;
   transition: all 0 ease-in-out;
-  background-color: ${({ playing }) => (playing ? 'transparent' : '#f55656')};
+  background-color: ${({ $playing }) => ($playing ? 'transparent' : '#f55656')};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -56,7 +56,7 @@ export const PlayPauseWrapper = styled.div<PlayPauseWrapperProps>`
   transition: all 0.2s ease-in-out;
 
   &:hover {
-    background: ${({ playing }) => (playing ? 'rgba(235,79,26,.1)' : '#f55656')};
+    background: ${({ $playing }) => ($playing ? 'rgba(235,79,26,.1)' : '#f55656')};
   }
 `;
 
@@ -65,9 +65,9 @@ export const PlayPauseWrapper = styled.div<PlayPauseWrapperProps>`
  */
 export const PlayPauseButton = styled.a<PlayPauseButtonProps>`
   content: '';
-  ${({ playing, preloadState }) =>
-    !playing &&
-    [PreloadState.NOT_STARTED, PreloadState.HAS_PRELOADED].includes(preloadState) &&
+  ${({ $playing, $preloadState }) =>
+    !$playing &&
+    [PreloadState.NOT_STARTED, PreloadState.HAS_PRELOADED].includes($preloadState) &&
     css`
       justify-content: center;
       width: 0;
@@ -79,8 +79,8 @@ export const PlayPauseButton = styled.a<PlayPauseButtonProps>`
       border-left: 12px solid #ffffff;
     `}
 
-   ${({ preloadState }) =>
-     preloadState === PreloadState.PRELOADING &&
+   ${({ $preloadState }) =>
+     $preloadState === PreloadState.PRELOADING &&
      css`
        justify-content: center;
        width: 0;
@@ -93,8 +93,8 @@ export const PlayPauseButton = styled.a<PlayPauseButtonProps>`
        animation: ${rotateLoader} 1.3s infinite;
      `}
 
-  ${({ playing }) =>
-    playing &&
+  ${({ $playing }) =>
+    $playing &&
     css`
       display: flex;
       justify-content: space-between;
@@ -172,7 +172,7 @@ export const BarPlayed = styled.div<BarPlayedProps>`
   -webkit-box-orient: horizontal;
   flex-direction: row-reverse;
   z-index: 2;
-  width: ${({ percent }) => `${percent}%`};
+  width: ${({ $percent }) => `${$percent}%`};
 `;
 
 export const VolumeWrapper = styled.div`
@@ -248,5 +248,5 @@ export const Volume = styled.div<VolumeProps>`
   position: absolute;
   top: 0;
   left: 0;
-  width: ${({ size }) => `${size}%`};
+  width: ${({ $size }) => `${$size}%`};
 `;

--- a/src/components/audioplayer/internal-audioplayer.tsx
+++ b/src/components/audioplayer/internal-audioplayer.tsx
@@ -131,13 +131,13 @@ export const InternalAudioPlayer = ({ audioRef, duration, durationInSeconds }: P
 
   return (
     <S.AudioPlayer>
-      <S.PlayPauseWrapper playing={isAudioPlaying()} onClick={changeState}>
-        <S.PlayPauseButton playing={isAudioPlaying()} preloadState={isPreloadingSong} />
+      <S.PlayPauseWrapper $playing={isAudioPlaying()} onClick={changeState}>
+        <S.PlayPauseButton $playing={isAudioPlaying()} $preloadState={isPreloadingSong} />
       </S.PlayPauseWrapper>
       <S.Time>{getCurrentTimeFormatted()}</S.Time>
       <S.Bar onClick={jumpToSongPosition}>
         <S.BarLoaded />
-        <S.BarPlayed percent={currentPositionPercent} />
+        <S.BarPlayed $percent={currentPositionPercent} />
       </S.Bar>
       <S.Duration>{duration}</S.Duration>
       <S.VolumeWrapper>
@@ -146,7 +146,7 @@ export const InternalAudioPlayer = ({ audioRef, duration, durationInSeconds }: P
         </S.VolumeButton>
         <S.VolumeBarWrapper onClick={jumpToVolumeSpeaker}>
           <S.VolumeBarInnerWrapper>
-            <S.Volume size={currentSpeakerPositionPercent} />
+            <S.Volume $size={currentSpeakerPositionPercent} />
           </S.VolumeBarInnerWrapper>
         </S.VolumeBarWrapper>
       </S.VolumeWrapper>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -40,7 +40,8 @@ const Header: FC<Props> = ({ pageTitle }) => {
 
       <header className="header-area">
         <div className="main-header-area">
-          <div className="classy-nav-container breakpoint-off light left">
+          {/* classyNav.js mutates breakpoint-on/off from viewport before React hydrates */}
+          <div className="classy-nav-container breakpoint-off light left" suppressHydrationWarning>
             <nav className="classy-navbar justify-content-between" id="pocaNav">
               <S.LogoWrapper>
                 <Link href="/" className="nav-brand">

--- a/src/components/language/language-header.tsx
+++ b/src/components/language/language-header.tsx
@@ -16,12 +16,12 @@ export const LanguageHeader = ({ currentLang }: LanguageHeaderProps) => {
   return (
     <>
       <S.Link>
-        <img src={`img/flags/${currentLang}.svg`} alt="Current flag" width={16} height={16} />
+        <img src={`/img/flags/${currentLang}.svg`} alt="Current flag" width={16} height={16} />
       </S.Link>
       <ul className="dropdown">
         <li>
           <S.Link onClick={changeLanguage('en')}>
-            <img src="img/flags/EN.svg" alt="French flag" width={16} height={16} /> EN
+            <img src="/img/flags/EN.svg" alt="English flag" width={16} height={16} /> EN
           </S.Link>
         </li>
         <li>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -12,6 +12,7 @@ i18next
   .init({
     lng: 'en',
     debug: publicAppConfig.translate.debug,
+    showSupportNotice: false,
     fallbackLng: 'en',
     preload: ['en', 'fr'],
     interpolation: {

--- a/src/lib/media-url.ts
+++ b/src/lib/media-url.ts
@@ -1,0 +1,19 @@
+/**
+ * Browsers block mixed content (HTTP subresources on HTTPS pages). APIs may still return http:// asset URLs.
+ * Localhost is left unchanged so local HTTP backends keep working in dev.
+ */
+export function upgradeHttpAssetUrl(url: string): string {
+  if (!url || !url.startsWith('http://')) {
+    return url;
+  }
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+      return url;
+    }
+    parsed.protocol = 'https:';
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,4 @@
-import App, { AppContext, AppInitialProps } from 'next/app';
-import { NextComponentType } from 'next';
+import type { AppProps } from 'next/app';
 import { Router } from 'next/router';
 
 import '../../public/style.css';
@@ -8,34 +7,6 @@ import '../lib/i18n';
 
 Router.events.on('routeChangeComplete', (url) => gtag.pageview(url));
 
-export type AppProps = Record<string, unknown> & AppInitialProps;
-
-const BaseApp = ({
-  Component,
-  pageProps,
-}: AppProps & {
-  Component: NextComponentType;
-}) => <Component {...pageProps} />;
-
-class AppRoot extends App<AppProps> {
-  /*
-   * A page that relies on publicRuntimeConfig must use getInitialProps to opt-out
-   * of Automatic Static Optimization. Runtime configuration won't be available to
-   * any page (or component in a page) without getInitialProps.
-   *
-   * So to use env variable in runtime, we need this
-   */
-  static getInitialProps = async (appContext: AppContext): Promise<AppProps> => {
-    const [appInitialProps] = await Promise.all([AppRoot.origGetInitialProps(appContext)]);
-
-    return {
-      ...appInitialProps,
-    };
-  };
-
-  render() {
-    return <BaseApp {...this.props} />;
-  }
-}
+const AppRoot = ({ Component, pageProps }: AppProps) => <Component {...pageProps} />;
 
 export default AppRoot;

--- a/src/server/services/episode.service.ts
+++ b/src/server/services/episode.service.ts
@@ -1,12 +1,23 @@
 import axios from 'axios';
+import { upgradeHttpAssetUrl } from '../../lib/media-url';
+import { Episode } from '../dto/episode.dto';
 import { HighLightEpisodeDto } from '../dto/highlight-episode.dto';
 import { request } from './backend';
 import { EpisodesListDto } from '../dto/episodes-list.dto';
 
+function normalizeEpisodeMedia(episode: Episode): Episode {
+  return {
+    ...episode,
+    coverImage: upgradeHttpAssetUrl(episode.coverImage),
+    audioLink: upgradeHttpAssetUrl(episode.audioLink),
+    itunesImageLink: upgradeHttpAssetUrl(episode.itunesImageLink),
+  };
+}
+
 export async function getHighLightEpisode(): Promise<HighLightEpisodeDto | null> {
   try {
     const { data } = await request.get('/api/episodes/highlight-episode');
-    return data;
+    return data ? normalizeEpisodeMedia(data) : null;
   } catch (e) {
     if (axios.isAxiosError(e) && e.response?.status === 404) {
       return null;
@@ -22,5 +33,5 @@ export async function getHighLightEpisode(): Promise<HighLightEpisodeDto | null>
 export async function getPublishedEpisodes(): Promise<EpisodesListDto> {
   const { data } = await request.get('/api/episodes');
 
-  return data;
+  return data.map(normalizeEpisodeMedia);
 }


### PR DESCRIPTION
## Summary
- **Hydration:** `suppressHydrationWarning` on `.classy-nav-container` because `classynav.js` flips `breakpoint-on` / `breakpoint-off` from viewport before React hydrates.
- **Images / audio on HTTPS:** Normalize episode `coverImage`, `audioLink`, and `itunesImageLink` from `http://` → `https://` when proxying from the API (skip `localhost` / `127.0.0.1`) to avoid mixed-content blocking.
- **Flags:** Use absolute `/img/flags/…` paths so they work on `/episodes` and other non-root routes.
- **Console:** `showSupportNotice: false` for i18next (removes Locize `console.info`).
- **React / styled-components:** Transient `$…` props on audio player styled components so custom props are not forwarded to DOM.
- **`_app`:** Remove legacy `getInitialProps` (runtime config is via `next.config.js` `env`); restores static prerender where applicable and drops the Next static-optimization warning.
- **Docs:** `.env.example` note to set `HOST=https://…` in production.

## Why
Production HTTPS was breaking remote `http://` episode assets; DevTools showed ClassyNav-related hydration errors and other avoidable console noise.

## Tests
- `pnpm run check`

## Follow-ups
- If any CDN still serves assets only over HTTP, fix at source; the client cannot fix a missing TLS endpoint.
- Bootstrap `*.css.map` 404 in Network tab is unchanged (optional cleanup).